### PR TITLE
fix: disable etag validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@eslint/js": "^9.18.0",
 				"@internationalized/date": "^3.8.1",
 				"@lucide/svelte": "^0.515.0",
-				"@openmeteo/file-reader": "^0.0.9",
+				"@openmeteo/file-reader": "^0.0.10",
 				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.22.0",
 				"@sveltejs/vite-plugin-svelte": "^6.0.0",
@@ -1212,20 +1212,20 @@
 			}
 		},
 		"node_modules/@openmeteo/file-format-wasm": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/@openmeteo/file-format-wasm/-/file-format-wasm-0.0.9.tgz",
-			"integrity": "sha512-3YxcKnFqmSm76H4DgpF+ak3d+NpO5JNcfyX+owXWr/VdYQ2OpVkR/fJcUmiD2pDXDxAPS2RLaVxEx6zgIrDXIw==",
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/@openmeteo/file-format-wasm/-/file-format-wasm-0.0.10.tgz",
+			"integrity": "sha512-b5hPQET0Zij0MmhSnxPaxjwjGey9fLHrNpzuejgdBMlfXi2kz8pZs2vdCFPEyOLWYIwywA4hqEJAjHh07yty/A==",
 			"dev": true,
 			"license": "GPL-2.0-only"
 		},
 		"node_modules/@openmeteo/file-reader": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/@openmeteo/file-reader/-/file-reader-0.0.9.tgz",
-			"integrity": "sha512-r/SdBfXBY67axidNE9bDnBRMsq5Oy0mVlG6wh6mKU0g2mwm3HZXFp7R93wN3ubl9saT75BdQE/kXYLuJAljjoQ==",
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/@openmeteo/file-reader/-/file-reader-0.0.10.tgz",
+			"integrity": "sha512-Qrcs5+Ztr6RtMzw8XSA7Er8tGxKRFLt1lVmNz4G+vr9YhTA2Of3eg3moOSmfxYrwPRYV4464utIMO8t7Fg/VFg==",
 			"dev": true,
 			"license": "GPL-2.0-only",
 			"dependencies": {
-				"@openmeteo/file-format-wasm": "^0.0.9"
+				"@openmeteo/file-format-wasm": "^0.0.10"
 			}
 		},
 		"node_modules/@polka/url": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@eslint/js": "^9.18.0",
 		"@internationalized/date": "^3.8.1",
 		"@lucide/svelte": "^0.515.0",
-		"@openmeteo/file-reader": "^0.0.9",
+		"@openmeteo/file-reader": "^0.0.10",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",

--- a/src/omaps-reader.ts
+++ b/src/omaps-reader.ts
@@ -23,7 +23,8 @@ export class OMapsFileReader {
 	async init(omUrl: string) {
 		this.dispose();
 		const s3_backend = new OmHttpBackend({
-			url: omUrl
+			url: omUrl,
+			eTagValidation: false
 		});
 		this.reader = await s3_backend.asCachedReader();
 	}


### PR DESCRIPTION
Single run files don't change. Therefore, we don't need to check if they did for cache validation.
This prevents preflight CORS requests, since the utilized "If-Unmodified-Since" and "If-Match" headers are not on the CORS-safelist.

xref: https://github.com/open-meteo/typescript-omfiles/pull/42/files