### PR TITLE
fix: Notify user of slow speed during raster tile request

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -361,7 +361,7 @@ export const addVectorLayer = () => {
 		});
 		omVectorSource = map.getSource('omVectorSource' + String(vectorRequests));
 		if (omVectorSource) {
-			omVectorSource.on('error', (_e) => {
+			omVectorSource.on('error', () => {
 				clearInterval(checkVectorSourceLoadedInterval);
 			});
 		}


### PR DESCRIPTION
### Fixes

- slow loading warning message is shown during loading instead of only after the tiles loaded.
- only show error messages from raster tiles, not vector tiles. Mostly they will be exactly the same. 