### PR TITLE
chore: delete codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*	@vincentvdwal @patrick-zippenfenig @terraputix


### PR DESCRIPTION
Codeowners file creates just too much noise for anyone involved and automatically assigns PRs (which I dislike). I think it would be better to just watch this project with the desired configuration. This way we would not be automatically assigned to each and every tiny PR, but would still not miss changes proposed by Dependabot.