### PR TITLE
fix: modelrun selected time dont always get parsed correctly from url

### DIFF
--- a/src/lib/components/time/time-selector.svelte
+++ b/src/lib/components/time/time-selector.svelte
@@ -45,6 +45,15 @@
 	// Tracks the currently selected date for display and navigation
 	let currentDate = $state(new Date($time));
 
+	// Reconcile currentDate with external $time changes (e.g. parsed from the URL on
+	// load, or jumps from other components). User interactions update currentDate
+	// directly before committing to $time, so when they match this is a no-op.
+	$effect(() => {
+		if (currentDate.getTime() !== $time.getTime()) {
+			currentDate = new SvelteDate($time);
+		}
+	});
+
 	// Converts the selected domain's model interval to hours for calculations
 	let modelInterval = $derived.by(() => {
 		let mI = $selectedDomain.model_interval;
@@ -203,6 +212,7 @@
 				);
 				time.set(nowTimeStep);
 				timeStep = nowTimeStep;
+				updateUrl('time', formatISOWithoutTimezone(nowTimeStep));
 			}
 		}
 
@@ -214,6 +224,7 @@
 					toast.warning('Date selected too new, using latest available time');
 					time.set(new Date(metaLastTime));
 					timeStep = new Date(metaLastTime);
+					updateUrl('time', formatISOWithoutTimezone(metaLastTime));
 				}
 			}
 		}
@@ -321,7 +332,6 @@
 
 	const jumpToCurrentTime = () => {
 		let date = new SvelteDate($now);
-		date.setTime(date.getTime() + metaFirstResolution); // next time step
 		const timeStep = findTimeStep(date, timeSteps);
 		if (timeStep) date = new SvelteDate(timeStep);
 		onDateChange(date);
@@ -372,7 +382,9 @@
 
 	const metaFirstTime = $derived(new Date($metaJson?.valid_times[0] as string));
 	const metaFirstResolution = $derived.by(() => {
-		const metaSecondTime = new Date($metaJson?.valid_times[1] as string);
+		// Fall back to a 1-hour step for runs that expose a single valid time.
+		if (!$metaJson || $metaJson.valid_times.length < 2) return MILLISECONDS_PER_HOUR;
+		const metaSecondTime = new Date($metaJson.valid_times[1] as string);
 		return metaSecondTime.getTime() - metaFirstTime.getTime();
 	});
 	const metaFirstResolutionHours = $derived(metaFirstResolution / MILLISECONDS_PER_HOUR);
@@ -381,8 +393,10 @@
 		new Date($metaJson?.valid_times[$metaJson?.valid_times.length - 1] as string)
 	);
 	const metaLastResolution = $derived.by(() => {
+		// Fall back to a 1-hour step for runs that expose a single valid time.
+		if (!$metaJson || $metaJson.valid_times.length < 2) return MILLISECONDS_PER_HOUR;
 		const metaSecondToLastTime = new Date(
-			$metaJson?.valid_times[$metaJson?.valid_times.length - 2] as string
+			$metaJson.valid_times[$metaJson.valid_times.length - 2] as string
 		);
 		return metaLastTime.getTime() - metaSecondToLastTime.getTime();
 	});
@@ -398,7 +412,7 @@
 		timeSteps ? timeSteps.findLastIndex((tS) => tS.getTime() <= $time.getTime()) : 0
 	);
 
-	metaJson.subscribe(async () => {
+	const unsubscribeMetaJson = metaJson.subscribe(async () => {
 		await tick();
 		if (dayContainer) {
 			dayContainerScrollLeft = dayContainer.scrollLeft;
@@ -530,69 +544,90 @@
 	let resizeTimeout: ReturnType<typeof setTimeout> | undefined;
 	const horizontalScrollSpeed = 1;
 
+	// Collects DOM listeners + the observer so they can be torn down on destroy.
+	const listenerController = new AbortController();
+	const signal = listenerController.signal;
+	let resizeObserver: ResizeObserver | undefined;
+
 	const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 	onMount(() => {
 		if (hoursHoverContainer) {
-			hoursHoverContainer.addEventListener('mousemove', (e) => {
-				if (hoursHoverContainerWidth)
-					hoverX = e.layerX + (isSafari ? hoursHoverContainerWidth / 2 : 0);
-			});
-			hoursHoverContainer.addEventListener('mouseout', () => {
-				hoverX = 0;
-			});
-			hoursHoverContainer.addEventListener('click', () => {
-				if (desktop.current) {
-					let validTime = false;
-					let timeStep =
-						timeStepsComplete[
-							Math.round(
-								(timeStepsComplete.length * (hoverX + dayContainerScrollLeft)) /
-									dayContainerScrollWidth
-							)
-						];
+			hoursHoverContainer.addEventListener(
+				'mousemove',
+				(e) => {
+					if (hoursHoverContainerWidth)
+						hoverX = e.layerX + (isSafari ? hoursHoverContainerWidth / 2 : 0);
+				},
+				{ signal }
+			);
+			hoursHoverContainer.addEventListener(
+				'mouseout',
+				() => {
+					hoverX = 0;
+				},
+				{ signal }
+			);
+			hoursHoverContainer.addEventListener(
+				'click',
+				() => {
+					if (desktop.current) {
+						let validTime = false;
+						let timeStep =
+							timeStepsComplete[
+								Math.round(
+									(timeStepsComplete.length * (hoverX + dayContainerScrollLeft)) /
+										dayContainerScrollWidth
+								)
+							];
 
-					if (timeStep && timeSteps)
-						for (let tS of timeSteps) {
-							if (tS.getTime() === timeStep.getTime()) {
-								validTime = true;
+						if (timeStep && timeSteps)
+							for (let tS of timeSteps) {
+								if (tS.getTime() === timeStep.getTime()) {
+									validTime = true;
+								}
 							}
-						}
 
-					if (
-						timeStep &&
-						!validTime &&
-						timeStep.getTime() > metaFirstTime.getTime() &&
-						timeStep.getTime() < metaLastTime.getTime()
-					) {
-						const foundTimeStep = findTimeStep(timeStep, timeSteps);
-						if (foundTimeStep) timeStep = new SvelteDate(foundTimeStep);
+						if (
+							timeStep &&
+							!validTime &&
+							timeStep.getTime() > metaFirstTime.getTime() &&
+							timeStep.getTime() < metaLastTime.getTime()
+						) {
+							const foundTimeStep = findTimeStep(timeStep, timeSteps);
+							if (foundTimeStep) timeStep = new SvelteDate(foundTimeStep);
+						}
+						if (timeStep) {
+							currentDate = timeStep;
+							onDateChange(timeStep);
+							centerDateButton(timeStep);
+						}
 					}
-					if (timeStep) {
-						currentDate = timeStep;
-						onDateChange(timeStep);
-						centerDateButton(timeStep);
-					}
-				}
-			});
+				},
+				{ signal }
+			);
 		}
 
-		window.addEventListener('resize', () => {
-			viewWidth = window.innerWidth;
-			if (dayContainer) {
-				dayContainerScrollLeft = dayContainer.scrollLeft;
-				dayContainerScrollWidth = dayContainer.scrollWidth;
-			}
-
-			clearTimeout(resizeTimeout);
-			resizeTimeout = setTimeout(() => {
-				if (dayContainer && !desktop.current) {
-					isScrolling = true;
-					centerDateButton(currentDate, false);
+		window.addEventListener(
+			'resize',
+			() => {
+				viewWidth = window.innerWidth;
+				if (dayContainer) {
+					dayContainerScrollLeft = dayContainer.scrollLeft;
+					dayContainerScrollWidth = dayContainer.scrollWidth;
 				}
-			}, 100);
-		});
 
-		const resizeObserver = new ResizeObserver(() => {
+				clearTimeout(resizeTimeout);
+				resizeTimeout = setTimeout(() => {
+					if (dayContainer && !desktop.current) {
+						isScrolling = true;
+						centerDateButton(currentDate, false);
+					}
+				}, 100);
+			},
+			{ signal }
+		);
+
+		resizeObserver = new ResizeObserver(() => {
 			if (dayContainer) {
 				dayContainerScrollLeft = dayContainer.scrollLeft;
 				dayContainerScrollWidth = dayContainer.scrollWidth;
@@ -646,50 +681,69 @@
 				onScrollEndEvent();
 			}, 150);
 
-			dayContainer.addEventListener('scroll', (e) => {
-				if (dayContainer) {
-					dayContainerScrollLeft = dayContainer.scrollLeft;
-				}
-				if (!desktop.current) {
-					throttledScrollEvent(e);
-				}
-			});
-			dayContainer.addEventListener('scrollend', throttledScrollEndEvent);
-			dayContainer.addEventListener('mousedown', (e) => {
-				if (!desktop.current) {
-					if (!dayContainer) return;
-					isDown = true;
-					startX = e.pageX - dayContainer.offsetLeft;
-					startY = e.pageY - dayContainer.offsetTop;
-					scrollLeft = dayContainer.scrollLeft;
-					scrollTop = dayContainer.scrollTop;
-					if (dayContainer) dayContainer.style.cursor = 'grabbing';
-				}
-			});
-			dayContainer.addEventListener('mouseup', () => {
-				if (!desktop.current) {
-					isDown = false;
-					if (dayContainer) dayContainer.style.cursor = 'grab';
-					onScrollEndEvent();
-				}
-			});
-			dayContainer.addEventListener('mousemove', (e) => {
-				if (!desktop.current) {
-					if (!isDown || !dayContainer) return;
-					e.preventDefault();
-					const x = e.pageX - dayContainer.offsetLeft;
-					const y = e.pageY - dayContainer.offsetTop;
-					const walkX = (x - startX) * horizontalScrollSpeed;
-					const walkY = (y - startY) * horizontalScrollSpeed;
-					dayContainer.scrollLeft = scrollLeft - walkX;
-					dayContainer.scrollTop = scrollTop - walkY;
-				}
-			});
+			dayContainer.addEventListener(
+				'scroll',
+				(e) => {
+					if (dayContainer) {
+						dayContainerScrollLeft = dayContainer.scrollLeft;
+					}
+					if (!desktop.current) {
+						throttledScrollEvent(e);
+					}
+				},
+				{ signal }
+			);
+			dayContainer.addEventListener('scrollend', throttledScrollEndEvent, { signal });
+			dayContainer.addEventListener(
+				'mousedown',
+				(e) => {
+					if (!desktop.current) {
+						if (!dayContainer) return;
+						isDown = true;
+						startX = e.pageX - dayContainer.offsetLeft;
+						startY = e.pageY - dayContainer.offsetTop;
+						scrollLeft = dayContainer.scrollLeft;
+						scrollTop = dayContainer.scrollTop;
+						if (dayContainer) dayContainer.style.cursor = 'grabbing';
+					}
+				},
+				{ signal }
+			);
+			dayContainer.addEventListener(
+				'mouseup',
+				() => {
+					if (!desktop.current) {
+						isDown = false;
+						if (dayContainer) dayContainer.style.cursor = 'grab';
+						onScrollEndEvent();
+					}
+				},
+				{ signal }
+			);
+			dayContainer.addEventListener(
+				'mousemove',
+				(e) => {
+					if (!desktop.current) {
+						if (!isDown || !dayContainer) return;
+						e.preventDefault();
+						const x = e.pageX - dayContainer.offsetLeft;
+						const y = e.pageY - dayContainer.offsetTop;
+						const walkX = (x - startX) * horizontalScrollSpeed;
+						const walkY = (y - startY) * horizontalScrollSpeed;
+						dayContainer.scrollLeft = scrollLeft - walkX;
+						dayContainer.scrollTop = scrollTop - walkY;
+					}
+				},
+				{ signal }
+			);
 		}
 	});
 
 	onDestroy(() => {
 		if (resizeTimeout) clearTimeout(resizeTimeout);
+		listenerController.abort();
+		resizeObserver?.disconnect();
+		unsubscribeMetaJson();
 	});
 
 	let previousModelSteps = $derived.by(() => {

--- a/src/lib/components/time/time-selector.svelte
+++ b/src/lib/components/time/time-selector.svelte
@@ -332,8 +332,15 @@
 
 	const jumpToCurrentTime = () => {
 		let date = new SvelteDate($now);
-		const timeStep = findTimeStep(date, timeSteps);
-		if (timeStep) date = new SvelteDate(timeStep);
+		// Snap to the next available step at or after now (valid_times is sorted
+		// ascending). Falls back to the nearest step when now is past the last step.
+		const nextStep = timeSteps?.find((tS) => tS.getTime() >= date.getTime());
+		if (nextStep) {
+			date = new SvelteDate(nextStep);
+		} else {
+			const timeStep = findTimeStep(date, timeSteps);
+			if (timeStep) date = new SvelteDate(timeStep);
+		}
 		onDateChange(date);
 		isScrolling = true;
 		centerDateButton(date);

--- a/src/lib/components/time/time-selector.svelte
+++ b/src/lib/components/time/time-selector.svelte
@@ -89,7 +89,11 @@
 			$modelRun ? $modelRun.getTime() === pMS.getTime() : false
 		);
 		if (currentIndex !== -1) {
-			onModelRunChange(previousModelSteps[currentIndex + 1]);
+			if (currentIndex + 1 < previousModelSteps.length) {
+				onModelRunChange(previousModelSteps[currentIndex + 1]);
+			} else {
+				toast.warning('Already on oldest model run');
+			}
 		}
 		if (
 			$modelRun &&

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -17,6 +17,11 @@ export const getInitialMetaData = async () => {
 		fetch(`${uri}/data_spatial/${domain.value}/in-progress.json`)
 	]);
 
+	// The domain may have changed while these requests were in flight (e.g. the
+	// initial persisted-domain load racing a URL-driven domain change). Discard the
+	// stale response so it can't clobber the current domain's metadata.
+	if (get(d) !== domain.value) return;
+
 	for (const res of [latestRes, inProgressRes]) {
 		if (!res.ok) {
 			loading.set(false);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -153,7 +153,12 @@
 
 		getInitialMetaDataPromise = (async () => {
 			await getInitialMetaData();
-			$metaJson = await getMetaData();
+			// Bail out if a newer domain change superseded this load while metadata was
+			// being fetched, so we don't commit another domain's metadata/time.
+			if (get(domain) !== newDomain) return;
+			const meta = await getMetaData();
+			if (get(domain) !== newDomain) return;
+			$metaJson = meta;
 
 			const timeSteps = $metaJson?.valid_times.map((validTime: string) => new Date(validTime));
 			const timeStep = findTimeStep($time, timeSteps);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -121,6 +121,9 @@
 			$map.addControl(new ClippingButton());
 
 			if (getInitialMetaDataPromise) await getInitialMetaDataPromise;
+			// Initial URL-driven setup is finished; from now on domain changes are
+			// user-initiated and should reset the selected model run.
+			initialLoadComplete = true;
 
 			addTerrainSource($map);
 			addTerrainSource($map, 'terrainSource2');
@@ -134,12 +137,18 @@
 	});
 
 	let getInitialMetaDataPromise: Promise<void> | undefined;
+	// Guards the domain subscription so the very first domain change (driven by the
+	// URL on page load) does not discard a model_run/time that was just parsed from
+	// the URL. Only genuine, user-initiated domain switches should reset the run.
+	let initialLoadComplete = false;
 	const domainSubscription = domain.subscribe(async (newDomain) => {
 		if ($domain !== newDomain) {
 			await tick(); // await the selectedDomain to be set
 			updateUrl('domain', newDomain);
-			$modelRun = undefined;
-			toast('Domain set to: ' + $selectedDomain.label);
+			if (initialLoadComplete) {
+				$modelRun = undefined;
+				toast('Domain set to: ' + $selectedDomain.label);
+			}
 		}
 
 		getInitialMetaDataPromise = (async () => {


### PR DESCRIPTION
### Summary

- Fixes the overwrite of the model_run and time when the domain wasn't aligned with localStorage and URL
- "c" or jumpToCurrent time now better aligns with "now"
- Block going before oldest model run