### PR TITLE
fix: new data endpoint

### DIFF
--- a/src/lib/components/time/time-selector.svelte
+++ b/src/lib/components/time/time-selector.svelte
@@ -24,7 +24,7 @@
 	} from '$lib/constants';
 	import { throttle } from '$lib/helpers';
 	import { changeOMfileURL } from '$lib/layers';
-	import { getMetaData } from '$lib/metadata';
+	import { getMetaData, tryGetMetaData } from '$lib/metadata';
 	import {
 		formatISOWithoutTimezone,
 		formatLocalDate,
@@ -306,10 +306,20 @@
 
 	// changes the selected model run and updates available time steps
 	const onModelRunChange = async (step: Date) => {
+		const previousModelRun = $modelRun;
+		const previousLocked = $modelRunLocked;
 		$loading = true;
 		$modelRunLocked = true;
 		$modelRun = step;
-		$metaJson = await getMetaData();
+		const meta = await tryGetMetaData();
+		if (!meta) {
+			// Failed load already toasted; put the selection back where it was
+			$modelRun = previousModelRun;
+			$modelRunLocked = previousLocked;
+			$loading = false;
+			return;
+		}
+		$metaJson = meta;
 
 		let closestTime = new SvelteDate($modelRun);
 		for (const vT of $metaJson.valid_times) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -13,8 +13,8 @@ export const fmtSelectedTime = (t: Date): string =>
 
 export const getBaseUri = (domainValue: string): string =>
 	dev && domainValue.startsWith('dwd_icon') && !domainValue.endsWith('eps')
-		? 'https://s3.servert.ch/data_spatial'
-		: 'https://openmeteo-data-spatial.b-cdn.net';
+		? 'https://data-spatial.open-meteo.com/data_spatial'
+		: 'https://data-spatial.open-meteo.com/data_spatial';
 // old: 'https://map-tiles.open-meteo.com/data_spatial';
 
 export const hashValue = (val: string): string => {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import { browser, dev } from '$app/environment';
+import { browser } from '$app/environment';
 
 /**
  * Pads a number with leading zeros to ensure 2 digits
@@ -11,11 +11,7 @@ export const fmtModelRun = (modelRun: Date): string =>
 export const fmtSelectedTime = (t: Date): string =>
 	`${t.getUTCFullYear()}-${pad(t.getUTCMonth() + 1)}-${pad(t.getUTCDate())}T${pad(t.getUTCHours())}${pad(t.getUTCMinutes())}`;
 
-export const getBaseUri = (domainValue: string): string =>
-	dev && domainValue.startsWith('dwd_icon') && !domainValue.endsWith('eps')
-		? 'https://data-spatial.open-meteo.com/data_spatial'
-		: 'https://data-spatial.open-meteo.com/data_spatial';
-// old: 'https://map-tiles.open-meteo.com/data_spatial';
+export const BASE_URI = 'https://data-spatial.open-meteo.com/data_spatial';
 
 export const hashValue = (val: string): string => {
 	// FNV-1a 32-bit – synchronous, fast, and sufficient for cache-busting keys.

--- a/src/lib/layers.ts
+++ b/src/lib/layers.ts
@@ -265,7 +265,12 @@ export const createManagers = (): void => {
 			loading.set(false);
 			refreshPopup();
 		},
-		onError: () => loading.set(false),
+		onError: () => {
+			loading.set(false);
+			// Without this the slot manager fails silently and just keeps the
+			// previous layer — on a first load that is an empty map with no hint
+			toast.error('Could not load the weather data for this view.', { id: 'om-data-error' });
+		},
 		slowLoadWarningMs: 10000,
 		onSlowLoad: () =>
 			toast.warning('Loading raster data might be limited by bandwidth or upstream server speed.')
@@ -281,7 +286,9 @@ export const createManagers = (): void => {
 			vectorContourLabelsLayer()
 		],
 		sourceSpec: (sourceUrl) => ({ url: sourceUrl, type: 'vector' }),
-		removeDelayMs: 250
+		removeDelayMs: 250,
+		onError: () =>
+			toast.error('Could not load the weather data for this view.', { id: 'om-data-error' })
 	});
 };
 

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -13,7 +13,7 @@ import {
 } from '$lib/stores/time';
 import { domain as d, selectedDomain, variable as v } from '$lib/stores/variables';
 
-import { fmtModelRun, getBaseUri } from './helpers';
+import { BASE_URI, fmtModelRun } from './helpers';
 import { formatISOWithoutTimezone } from './time-format';
 import { findTimeStep } from './time-utils';
 import { updateUrl } from './url';
@@ -25,12 +25,11 @@ import { updateUrl } from './url';
  */
 export const getInitialMetaData = async (): Promise<boolean> => {
 	const domain = get(selectedDomain);
-	const uri = getBaseUri(domain.value);
 
 	try {
 		const [latestRes, inProgressRes] = await Promise.all([
-			fetch(`${uri}/${domain.value}/latest.json`),
-			fetch(`${uri}/${domain.value}/in-progress.json`)
+			fetch(`${BASE_URI}/${domain.value}/latest.json`),
+			fetch(`${BASE_URI}/${domain.value}/in-progress.json`)
 		]);
 
 		// The domain may have changed while these requests were in flight (e.g. the
@@ -61,12 +60,8 @@ const toDate = (dateString: string | undefined): Date | undefined =>
 const matchesModelRun = (referenceTime: Date | undefined, modelRun: Date): boolean =>
 	referenceTime?.getTime() === modelRun.getTime();
 
-const fetchMetaData = async (
-	uri: string,
-	domain: string,
-	modelRun: Date
-): Promise<DomainMetaDataJson> => {
-	const url = `${uri}/${domain}/${fmtModelRun(modelRun)}/meta.json`;
+const fetchMetaData = async (domain: string, modelRun: Date): Promise<DomainMetaDataJson> => {
+	const url = `${BASE_URI}/${domain}/${fmtModelRun(modelRun)}/meta.json`;
 	const res = await fetch(url);
 
 	if (!res.ok) {
@@ -79,7 +74,6 @@ const fetchMetaData = async (
 
 export const getMetaData = async (): Promise<DomainMetaDataJson> => {
 	const domain = get(d);
-	const uri = getBaseUri(domain);
 
 	const latest = get(l);
 	const latestReferenceTime = toDate(latest?.reference_time);
@@ -96,7 +90,7 @@ export const getMetaData = async (): Promise<DomainMetaDataJson> => {
 		? (latest as DomainMetaDataJson)
 		: matchesModelRun(inProgressReferenceTime, modelRun)
 			? (inProgress as DomainMetaDataJson)
-			: await fetchMetaData(uri, domain, modelRun);
+			: await fetchMetaData(domain, modelRun);
 
 	result.valid_times.sort();
 	return result;

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,6 +1,7 @@
 import { get } from 'svelte/store';
 
 import { type DomainMetaDataJson, VARIABLE_PREFIX } from '@openmeteo/weather-map-layer';
+import { toast } from 'svelte-sonner';
 
 import { loading } from '$lib/stores/preferences';
 import {
@@ -17,27 +18,40 @@ import { formatISOWithoutTimezone } from './time-format';
 import { findTimeStep } from './time-utils';
 import { updateUrl } from './url';
 
-export const getInitialMetaData = async () => {
+/**
+ * Load the domain's latest/in-progress run info. Returns false when the load
+ * failed (an error toast has been shown) or when the domain changed while the
+ * requests were in flight; callers must not continue to meta.json then.
+ */
+export const getInitialMetaData = async (): Promise<boolean> => {
 	const domain = get(selectedDomain);
 	const uri = getBaseUri(domain.value);
 
-	const [latestRes, inProgressRes] = await Promise.all([
-		fetch(`${uri}/${domain.value}/latest.json`),
-		fetch(`${uri}/${domain.value}/in-progress.json`)
-	]);
+	try {
+		const [latestRes, inProgressRes] = await Promise.all([
+			fetch(`${uri}/${domain.value}/latest.json`),
+			fetch(`${uri}/${domain.value}/in-progress.json`)
+		]);
 
-	// The domain may have changed while these requests were in flight (e.g. the
-	// initial persisted-domain load racing a URL-driven domain change). Discard the
-	// stale response so it can't clobber the current domain's metadata.
-	if (get(d) !== domain.value) return;
+		// The domain may have changed while these requests were in flight (e.g. the
+		// initial persisted-domain load racing a URL-driven domain change). Discard the
+		// stale response so it can't clobber the current domain's metadata.
+		if (get(d) !== domain.value) return false;
 
-	for (const res of [latestRes, inProgressRes]) {
-		if (!res.ok) {
-			loading.set(false);
-			throw new Error(`HTTP ${res.status}`);
+		for (const res of [latestRes, inProgressRes]) {
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
 		}
-		if (res.url.includes('latest.json')) l.set(await res.json());
-		if (res.url.includes('in-progress.json')) iP.set(await res.json());
+		l.set(await latestRes.json());
+		iP.set(await inProgressRes.json());
+		return true;
+	} catch (e) {
+		loading.set(false);
+		// Fixed id: the periodic refresh retries every few minutes, and a dead
+		// server should update the one toast rather than stack a new one
+		toast.error(`Could not load run info for ${domain.label}: ${(e as Error).message}`, {
+			id: 'run-info-error'
+		});
+		return false;
 	}
 };
 
@@ -88,17 +102,32 @@ export const getMetaData = async (): Promise<DomainMetaDataJson> => {
 	return result;
 };
 
+/**
+ * `getMetaData`, but a failed meta.json load surfaces as an error toast
+ * instead of an exception; returns undefined so callers can bail out.
+ */
+export const tryGetMetaData = async (): Promise<DomainMetaDataJson | undefined> => {
+	try {
+		return await getMetaData();
+	} catch (e) {
+		loading.set(false);
+		toast.error(`Could not load metadata: ${(e as Error).message}`, { id: 'metadata-error' });
+		return undefined;
+	}
+};
+
 // Full metadata refresh for a domain: fetches the latest/in-progress run info
 // and the run's meta.json, clamps the selected time to the valid times in the
 // metadata (falling back to the first valid time), and re-matches the
 // variable. Bails out if a newer domain change superseded this load while
 // metadata was being fetched, so we don't commit another domain's
-// metadata/time.
+// metadata/time, and when a load failed (already surfaced as an error toast),
+// so the map keeps running on whatever state it has.
 export const loadDomainMetaData = async (newDomain: string) => {
-	await getInitialMetaData();
+	if (!(await getInitialMetaData())) return;
 	if (get(d) !== newDomain) return;
-	const meta = await getMetaData();
-	if (get(d) !== newDomain) return;
+	const meta = await tryGetMetaData();
+	if (!meta || get(d) !== newDomain) return;
 	mJ.set(meta);
 
 	const timeSteps = meta.valid_times.map((validTime: string) => new Date(validTime));

--- a/src/lib/prefetch.ts
+++ b/src/lib/prefetch.ts
@@ -5,7 +5,7 @@ import { currentBounds, getProtocolInstance, getRanges } from '@openmeteo/weathe
 import { omProtocolSettings } from '$lib/stores/om-protocol-settings';
 
 import { MILLISECONDS_PER_DAY } from './constants';
-import { fmtModelRun, fmtSelectedTime, getBaseUri } from './helpers';
+import { BASE_URI, fmtModelRun, fmtSelectedTime } from './helpers';
 import { selectedDomain } from './stores/variables';
 
 import type { DomainMetaDataJson } from '@openmeteo/weather-map-layer';
@@ -124,9 +124,6 @@ export const prefetchData = async (
 		const ranges = getRanges(get(selectedDomain).grid, currentBounds);
 		const omFileReader = instance.omFileReader;
 
-		// Build base URL
-		const uri = getBaseUri(domain);
-
 		let successCount = 0;
 		const totalCount = timeSteps.length;
 
@@ -134,7 +131,7 @@ export const prefetchData = async (
 		const prefetchSingle = async (timeStep: Date): Promise<boolean> => {
 			if (signal?.aborted) return false;
 
-			const url = `${uri}/${domain}/${fmtModelRun(modelRun)}/${fmtSelectedTime(timeStep)}.om`;
+			const url = `${BASE_URI}/${domain}/${fmtModelRun(modelRun)}/${fmtSelectedTime(timeStep)}.om`;
 
 			try {
 				await omFileReader.setToOmFile(url);

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -18,7 +18,7 @@ import {
 	DEFAULT_TILE_SIZE
 } from '$lib/constants';
 import { checkHighDefinition } from '$lib/helpers';
-import { getInitialMetaData, getMetaData } from '$lib/metadata';
+import { getInitialMetaData, tryGetMetaData } from '$lib/metadata';
 
 import { cacheBlockSizeKb, cacheMaxBytesMb, customColorScales } from './om-protocol-settings';
 import { inProgress, latest, metaJson, modelRun, modelRunLocked, now, time } from './time';
@@ -112,8 +112,12 @@ export const resetStates = async () => {
 	latest.set(undefined);
 	inProgress.set(undefined);
 	modelRun.set(undefined);
-	await getInitialMetaData();
-	metaJson.set(await getMetaData());
+	// A failed load already toasted; the reset continues with the run info
+	// (and metadata) simply left unset
+	if (await getInitialMetaData()) {
+		const meta = await tryGetMetaData();
+		if (meta) metaJson.set(meta);
+	}
 
 	preferences.set(defaultPreferences);
 	vectorOptions.set(defaultVectorOptions);

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -31,7 +31,7 @@ import {
 	parseClipCountriesParam,
 	serializeClipCountriesParam
 } from './clipping';
-import { fmtModelRun, fmtSelectedTime, getBaseUri, hashValue } from './helpers';
+import { BASE_URI, fmtModelRun, fmtSelectedTime, hashValue } from './helpers';
 import { clippingCountryCodes } from './stores/clipping';
 import { omProtocolSettings } from './stores/om-protocol-settings';
 import { formatISOUTCWithZ, parseISOWithoutTimezone } from './time-format';
@@ -166,7 +166,7 @@ const memorisedHash = (json: string, cachedJson: string, cachedHash: string) => 
 
 export const getOMUrl = () => {
 	const domain = get(d);
-	const base = `${getBaseUri(domain)}/${domain}`;
+	const base = `${BASE_URI}/${domain}`;
 	const modelRun = get(mR);
 	if (!modelRun) return undefined;
 	const selectedTime = get(time);
@@ -221,7 +221,7 @@ export const getNextOmUrls = (
 	domain: Domain,
 	metaJson: DomainMetaDataJson | undefined
 ): [string | undefined, string | undefined] => {
-	const base = `${getBaseUri(domain.value)}/${domain.value}`;
+	const base = `${BASE_URI}/${domain.value}`;
 	const date = get(time);
 	const dateString = formatISOUTCWithZ(date);
 


### PR DESCRIPTION
## Switch to the data-spatial endpoint

All weather data (`latest.json`, `in-progress.json`, `meta.json`, `.om` files) now
comes from `https://data-spatial.open-meteo.com/data_spatial`, replacing the Bunny
CDN (`openmeteo-data-spatial.b-cdn.net`) and the dev-only `s3.servert.ch` override.

Since the URL no longer varies per domain or environment, `getBaseUri(domainValue)`
is replaced by a plain `BASE_URI` constant, and the `uri` parameter/locals that
threaded it through `metadata.ts` and `prefetch.ts` are gone.
