### PR TITLE
fix: adopt one-step om reader api and warmFile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@lucide/svelte": "^1.23.0",
 				"@openmeteo/file-reader": "^0.0.16",
-				"@openmeteo/weather-map-layer": "^0.0.20",
+				"@openmeteo/weather-map-layer": "github:open-meteo/weather-map-layer#11cafa89503066e13d4b16e1dfdbe9c352e23fbf",
 				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.69.1",
 				"@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -675,13 +675,13 @@
 		},
 		"node_modules/@openmeteo/weather-map-layer": {
 			"version": "0.0.20",
-			"resolved": "https://registry.npmjs.org/@openmeteo/weather-map-layer/-/weather-map-layer-0.0.20.tgz",
-			"integrity": "sha512-raVmrF33t7mbfxRqC6/QYs/ZousupCN11lpVUlTvZbxepMulVtnMTkxpuYONT5ToAEgR9wOcyTWohtPaQtffWQ==",
+			"resolved": "git+ssh://git@github.com/open-meteo/weather-map-layer.git#11cafa89503066e13d4b16e1dfdbe9c352e23fbf",
+			"integrity": "sha512-C81fiVDZf0YYVGuTZ2SXQizukRjKJB1Alc0lTpT/4hyNSHZ3a559rtckRZtYXh7OTgZZNyX2hQimQF99RY6+9Q==",
 			"dev": true,
 			"dependencies": {
 				"@mapbox/tilebelt": "^2.0.3",
 				"@mapbox/vector-tile": "^3.0.0",
-				"@openmeteo/file-reader": "^0.0.16",
+				"@openmeteo/file-reader": "^0.0.18",
 				"maplibre-gl": "^5.20.1",
 				"pbf": "^5.1.0",
 				"point-in-polygon-hao": "^1.2.4"
@@ -697,6 +697,23 @@
 				"@mapbox/point-geometry": "~1.1.0",
 				"@types/geojson": "^7946.0.16",
 				"pbf": "^5.0.0"
+			}
+		},
+		"node_modules/@openmeteo/weather-map-layer/node_modules/@openmeteo/file-format-wasm": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@openmeteo/file-format-wasm/-/file-format-wasm-0.0.18.tgz",
+			"integrity": "sha512-t19P/qFpksYMOai4Kwk8bA44Sb8Q9n6De2V4cnEqAYljJEjPAJCylKOVVFlvdNzVN96Kf78qYPnhA69NKDYndA==",
+			"dev": true,
+			"license": "GPL-2.0-only"
+		},
+		"node_modules/@openmeteo/weather-map-layer/node_modules/@openmeteo/file-reader": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@openmeteo/file-reader/-/file-reader-0.0.18.tgz",
+			"integrity": "sha512-Bjuo2G9Cg5j3L2EstqaJ3iyugwdROYpA56cK2ISfEnRYCR8KsCWQ18oKAmDn7kUUXftQenzTzQTuFRzbxrLpiA==",
+			"dev": true,
+			"license": "GPL-2.0-only",
+			"dependencies": {
+				"@openmeteo/file-format-wasm": "^0.0.18"
 			}
 		},
 		"node_modules/@openmeteo/weather-map-layer/node_modules/pbf": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@lucide/svelte": "^1.23.0",
 				"@openmeteo/file-reader": "^0.0.16",
-				"@openmeteo/weather-map-layer": "github:open-meteo/weather-map-layer#11cafa89503066e13d4b16e1dfdbe9c352e23fbf",
+				"@openmeteo/weather-map-layer": "^0.1.0",
 				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.69.1",
 				"@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -674,9 +674,9 @@
 			}
 		},
 		"node_modules/@openmeteo/weather-map-layer": {
-			"version": "0.0.20",
-			"resolved": "git+ssh://git@github.com/open-meteo/weather-map-layer.git#11cafa89503066e13d4b16e1dfdbe9c352e23fbf",
-			"integrity": "sha512-C81fiVDZf0YYVGuTZ2SXQizukRjKJB1Alc0lTpT/4hyNSHZ3a559rtckRZtYXh7OTgZZNyX2hQimQF99RY6+9Q==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@openmeteo/weather-map-layer/-/weather-map-layer-0.1.0.tgz",
+			"integrity": "sha512-mwcYjgGl3qjxi4NL3XdA3WuxTGG0qO7N7pOy0uN/SFdpEYPJe98gzJo0VfVRLHC0k4kwTKA9vymK/bwJ2QIIXQ==",
 			"dev": true,
 			"dependencies": {
 				"@mapbox/tilebelt": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@lucide/svelte": "^1.23.0",
 		"@openmeteo/file-reader": "^0.0.16",
-		"@openmeteo/weather-map-layer": "^0.0.20",
+		"@openmeteo/weather-map-layer": "github:open-meteo/weather-map-layer#11cafa89503066e13d4b16e1dfdbe9c352e23fbf",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.69.1",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@lucide/svelte": "^1.23.0",
 		"@openmeteo/file-reader": "^0.0.16",
-		"@openmeteo/weather-map-layer": "github:open-meteo/weather-map-layer#11cafa89503066e13d4b16e1dfdbe9c352e23fbf",
+		"@openmeteo/weather-map-layer": "^0.1.0",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.69.1",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/src/lib/prefetch.ts
+++ b/src/lib/prefetch.ts
@@ -134,8 +134,7 @@ export const prefetchData = async (
 			const url = `${BASE_URI}/${domain}/${fmtModelRun(modelRun)}/${fmtSelectedTime(timeStep)}.om`;
 
 			try {
-				await omFileReader.setToOmFile(url);
-				await omFileReader.prefetchVariable(variable, ranges, signal);
+				await omFileReader.prefetchVariable(url, variable, ranges, signal);
 				return true;
 			} catch {
 				// Silently continue on errors

--- a/src/lib/stores/om-protocol-settings.ts
+++ b/src/lib/stores/om-protocol-settings.ts
@@ -61,10 +61,9 @@ export const omProtocolSettings: Writable<OmProtocolSettings> = writable({
 		const nextOmUrls = getNextOmUrls(state.omFileUrl, get(selectedDomain), get(metaJson));
 		for (const nextOmUrl of nextOmUrls) {
 			if (nextOmUrl === undefined) continue;
-			omFileReader.setToOmFile(nextOmUrl);
-			// This will trigger a request to the tail of the file and cache it
-			// Not requesting a real variable ensures that we don't request any additional data.
-			omFileReader.prefetchVariable('not_a_real_variable');
+			// Caches the file header/trailer and root metadata without requesting
+			// any variable data. Best-effort: the file may not be published yet.
+			omFileReader.warmFile(nextOmUrl).catch(() => {});
 		}
 		if (
 			state.dataOptions.domain.value === 'ecmwf_ifs' &&

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -1,7 +1,11 @@
 import { MediaQuery } from 'svelte/reactivity';
 import { type Writable, get, writable } from 'svelte/store';
 
-import { type InterpolationMethod, clearBlockCache } from '@openmeteo/weather-map-layer';
+import {
+	type InterpolationMethod,
+	clearBackends,
+	clearBlockCache
+} from '@openmeteo/weather-map-layer';
 import { setMode } from 'mode-watcher';
 import { type Persisted, persisted } from 'svelte-persisted-store';
 
@@ -158,6 +162,7 @@ export const resetStates = async () => {
 
 	setMode('system');
 
+	clearBackends();
 	await clearBlockCache();
 };
 


### PR DESCRIPTION
Adopts the atomic reader API from weather-map-layer: prefetch passes the URL per
call — previously the 8 parallel workers clobbered each other's `setToOmFile`
state and prefetched the wrong timesteps — and next-timestep warmup uses the new
`warmFile()` instead of requesting a fake variable.
